### PR TITLE
Surface errors through pstore

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -15,21 +15,20 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-	"github.com/glassechidna/pstore/common"
 	"os"
+
+	"github.com/glassechidna/pstore/common"
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
 var execCmd = &cobra.Command{
 	Use:   "exec",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
+	Short: "exec will seed the current environment with ssm parameters (if it exists) execute a command",
+	Long: `example:
+	AWS_REGION=us-east-1 PSTORE_DBSTRING=MyDatabaseString pstore exec -- 'echo val is $DBSTRING'
+	val is SomeSuperSecretDbString`,
 
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		simplePrefix := viper.GetString("prefix")
 		tagPrefix := viper.GetString("tag-prefix")

--- a/cmd/powershell.go
+++ b/cmd/powershell.go
@@ -17,21 +17,22 @@ package cmd
 import (
 	"fmt"
 
+	"strings"
+
+	"github.com/glassechidna/pstore/common"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"strings"
-	"github.com/glassechidna/pstore/common"
 )
 
 var powershellCmd = &cobra.Command{
 	Use:   "powershell",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "same as shell but for windows",
+	Long: `Example:
+	$Env:PSTORE_DBSTRING = "MyDatabaseString"
+	$Cmd = (pstore powershell mycompany-prod) | Out-String
+	Invoke-Expression $Cmd
+	Do-SomethingWith -DbString $DBSTRING
+	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		simplePrefix := viper.GetString("prefix")
 		tagPrefix := viper.GetString("tag-prefix")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,13 +26,10 @@ var cfgFile string
 
 var RootCmd = &cobra.Command{
 	Use:   "pstore",
-	Short: "A brief description of your application",
-	Long: `A longer description that spans multiple lines and likely contains
-examples and usage of using your application. For example:
+	Short: "pstore is a tiny utility to make usage of AWS Parameter Store an absolute breeze. Simply prefix your application launch with pstore exec <yourapp> and you're up and running - in dev or prod.",
+	Long: `pstore is usable out of the box. By default it looks for environment variables with a PSTORE_ prefix. For example, PSTORE_DBSTRING=MyDatabaseString asks AWS to decrypt the parameter named MyDatabaseString and stores the decrypted value in a new environment variable named DBSTRING. If there are no envvars with the PSTORE_ prefix, it's essentially a noop - so the same command can be used in local dev and in prod.
 
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	If pstore fails to decrypt any envvars it will exit instead of launching your application.`,
 }
 
 // Execute adds all child commands to the root command sets flags appropriately.
@@ -64,8 +61,8 @@ func initConfig() {
 	}
 
 	viper.SetConfigName(".pstore") // name of config file (without extension)
-	viper.AddConfigPath("$HOME")  // adding home directory as first search path
-	viper.AutomaticEnv()          // read in environment variables that match
+	viper.AddConfigPath("$HOME")   // adding home directory as first search path
+	viper.AutomaticEnv()           // read in environment variables that match
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -17,21 +17,21 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/spf13/cobra"
-	"github.com/glassechidna/pstore/common"
-	"github.com/spf13/viper"
 	"strings"
+
+	"github.com/glassechidna/pstore/common"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var shellCmd = &cobra.Command{
 	Use:   "shell",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "shell will seed your session with environment with the ssm parameters, and will not execute a child process",
+	Long: `Example:
+	#!/bin/bash
+	# do some stuff ...
+	eval $(PSTORE_DBSTRING=MyDatabaseString pstore shell)
+	echo $DBSTRING # will echo out your secret string!`,
 	Run: func(cmd *cobra.Command, args []string) {
 		simplePrefix := viper.GetString("prefix")
 		tagPrefix := viper.GetString("tag-prefix")


### PR DESCRIPTION
Its kinda difficult to debug errors with `pstore` since the underlying error is gobbled up, and not surfaced through the logs. This change should surface those errors especially if wasn't able to successfully decrypt the parameter.

I tested a few times and it seemed it to work for my use cases, but might need to be tested with the tags..

I also have included some changes to improve the output of the shell documentation.. just cause it bugged me that it pointed to Cobra.